### PR TITLE
fix: make default-bench test preset standalone to avoid filter conflict

### DIFF
--- a/template/tool/cmake/platform/common/CMakePresets.json.jinja
+++ b/template/tool/cmake/platform/common/CMakePresets.json.jinja
@@ -85,13 +85,20 @@
             "name": "default-bench",
             "description": "Base preset for benchmark tests",
             "hidden": true,
-            "inherits": [
-                "default"
-            ],
+            "output": {
+                "outputOnFailure": true,
+                "shortProgress": true,
+                "debug": true,
+                "verbosity": "verbose"
+            },
             "filter": {
                 "include": {
                     "label": "benchmark"
                 }
+            },
+            "execution": {
+                "noTestsAction": "error",
+                "stopOnFailure": true
             }
         }{% endif %}
     ]


### PR DESCRIPTION
The default-bench preset inherited from default, which has an exclude filter for the benchmark label. CMake merges both filters during inheritance, causing benchmarks to be marked as Not Run.

Replace the inheritance with explicit output and execution settings so the benchmark include filter is not overridden.